### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tmunzer/mistapi_python/security/code-scanning/3](https://github.com/tmunzer/mistapi_python/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs read access to the repository contents and write access to pull requests (if applicable). Since the workflow uploads coverage reports, it might also require write access to the `contents` scope if it interacts with the repository.

The `permissions` block will be added at the root level, applying to all jobs in the workflow. This ensures consistency and avoids the need to define permissions for each job individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
