### PR TITLE
feat: import the mist_openapi repo as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mist_openapi"]
+	path = mist_openapi
+	url = https://github.com/Mist-Automation-Programmability/mist_openapi.git

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,19 @@ help: ## Show this help message
 	@echo 'Targets:'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-init: ## Development setup
+setup-openapi: ## Initialize or update OpenAPI submodule
+	@if [ ! -d "mist_openapi/.git" ]; then \
+		echo "Initializing OpenAPI submodule..."; \
+		git submodule update --init mist_openapi; \
+	fi
+	@echo "Updating OpenAPI submodule..."; \
+	git submodule update --remote mist_openapi
+
+generate: setup-openapi ## Run the code generation script
+	uv run python generate_from_openapi.py $(VERSION)
+	$(MAKE) format
+
+init: setup-openapi ## Development setup with OpenAPI
 	uv sync
 
 install: ## Install project in development mode
@@ -57,10 +69,6 @@ publish-test: clean build ## Publish to test PyPI
 
 publish: clean build ## Publish to PyPI
 	uv run twine upload dist/*
-
-generate: ## Run the code generation script
-	cd mist_openapi && git pull && cd ..
-	uv run python generate_from_openapi.py $(VERSION)
 
 deps: ## Show dependency tree
 	uv tree

--- a/src/mistapi/api/v1/orgs/devices.py
+++ b/src/mistapi/api/v1/orgs/devices.py
@@ -236,6 +236,7 @@ def searchOrgDeviceEvents(
     timestamp: str | None = None,
     type: str | None = None,
     last_by: str | None = None,
+    includes: str | None = None,
     limit: int = 100,
     start: int | None = None,
     end: int | None = None,
@@ -262,6 +263,7 @@ def searchOrgDeviceEvents(
     timestamp : str
     type : str
     last_by : str
+    includes : str
     limit : int, default: 100
     start : int
     end : int
@@ -289,6 +291,8 @@ def searchOrgDeviceEvents(
         query_params["type"] = str(type)
     if last_by:
         query_params["last_by"] = str(last_by)
+    if includes:
+        query_params["includes"] = str(includes)
     if limit:
         query_params["limit"] = str(limit)
     if start:

--- a/src/mistapi/api/v1/orgs/nac_clients.py
+++ b/src/mistapi/api/v1/orgs/nac_clients.py
@@ -352,6 +352,11 @@ def searchOrgNacClients(
     status: str | None = None,
     type: str | None = None,
     mdm_compliance: str | None = None,
+    family: str | None = None,
+    model: str | None = None,
+    os: str | None = None,
+    hostname: str | None = None,
+    mfg: str | None = None,
     mdm_provider: str | None = None,
     sort: str | None = None,
     usermac_label: list | None = None,
@@ -389,9 +394,15 @@ def searchOrgNacClients(
     ap : str
     mac : str
     mdm_managed : bool
-    status : str
+    status : str{'permitted', 'session_started', 'session_ended', 'denied'}
+      Connection status of client i.e "permitted", "denied, "session_stared", "session_ended"
     type : str
     mdm_compliance : str
+    family : str
+    model : str
+    os : str
+    hostname : str
+    mfg : str
     mdm_provider : str
     sort : str
     usermac_label : list
@@ -443,6 +454,16 @@ def searchOrgNacClients(
         query_params["type"] = str(type)
     if mdm_compliance:
         query_params["mdm_compliance"] = str(mdm_compliance)
+    if family:
+        query_params["family"] = str(family)
+    if model:
+        query_params["model"] = str(model)
+    if os:
+        query_params["os"] = str(os)
+    if hostname:
+        query_params["hostname"] = str(hostname)
+    if mfg:
+        query_params["mfg"] = str(mfg)
     if mdm_provider:
         query_params["mdm_provider"] = str(mdm_provider)
     if sort:

--- a/src/mistapi/api/v1/orgs/setting.py
+++ b/src/mistapi/api/v1/orgs/setting.py
@@ -742,6 +742,68 @@ def verifyOrgCustomBucket(
     return resp
 
 
+def udpateOrgAtpAllowedList(
+    mist_session: _APISession, org_id: str, body: dict
+) -> _APIResponse:
+    """
+    API doc: https://www.juniper.net/documentation/us/en/software/mist/api/http/api/orgs/integration-skyatp/udpate-org-atp-allowed-list
+
+    PARAMS
+    -----------
+    mistapi.APISession : mist_session
+        mistapi session including authentication and Mist host information
+
+    PATH PARAMS
+    -----------
+    org_id : str
+
+    BODY PARAMS
+    -----------
+    body : dict
+        JSON object to send to Mist Cloud (see API doc above for more details)
+
+    RETURN
+    -----------
+    mistapi.APIResponse
+        response from the API call
+    """
+
+    uri = f"/api/v1/orgs/{org_id}/setting/skyatp/secintel_allowlist"
+    resp = mist_session.mist_put(uri=uri, body=body)
+    return resp
+
+
+def udpateOrgAtpBlockedList(
+    mist_session: _APISession, org_id: str, body: dict
+) -> _APIResponse:
+    """
+    API doc: https://www.juniper.net/documentation/us/en/software/mist/api/http/api/orgs/integration-skyatp/udpate-org-atp-blocked-list
+
+    PARAMS
+    -----------
+    mistapi.APISession : mist_session
+        mistapi session including authentication and Mist host information
+
+    PATH PARAMS
+    -----------
+    org_id : str
+
+    BODY PARAMS
+    -----------
+    body : dict
+        JSON object to send to Mist Cloud (see API doc above for more details)
+
+    RETURN
+    -----------
+    mistapi.APIResponse
+        response from the API call
+    """
+
+    uri = f"/api/v1/orgs/{org_id}/setting/skyatp/secintel_blocklist"
+    resp = mist_session.mist_put(uri=uri, body=body)
+    return resp
+
+
 def getOrgSkyAtpIntegration(mist_session: _APISession, org_id: str) -> _APIResponse:
     """
     API doc: https://www.juniper.net/documentation/us/en/software/mist/api/http/api/orgs/integration-skyatp/get-org-sky-atp-integration
@@ -850,68 +912,6 @@ def udpateOrgAtpIntegration(
     """
 
     uri = f"/api/v1/orgs/{org_id}/setting/skyatp/setup"
-    resp = mist_session.mist_put(uri=uri, body=body)
-    return resp
-
-
-def udpateOrgAtpAllowedList(
-    mist_session: _APISession, org_id: str, body: dict
-) -> _APIResponse:
-    """
-    API doc: https://www.juniper.net/documentation/us/en/software/mist/api/http/api/orgs/integration-skyatp/udpate-org-atp-allowed-list
-
-    PARAMS
-    -----------
-    mistapi.APISession : mist_session
-        mistapi session including authentication and Mist host information
-
-    PATH PARAMS
-    -----------
-    org_id : str
-
-    BODY PARAMS
-    -----------
-    body : dict
-        JSON object to send to Mist Cloud (see API doc above for more details)
-
-    RETURN
-    -----------
-    mistapi.APIResponse
-        response from the API call
-    """
-
-    uri = f"/api/v1/orgs/{org_id}/setting/skyatp/setup/secintel_allowlist"
-    resp = mist_session.mist_put(uri=uri, body=body)
-    return resp
-
-
-def udpateOrgAtpBlockedList(
-    mist_session: _APISession, org_id: str, body: dict
-) -> _APIResponse:
-    """
-    API doc: https://www.juniper.net/documentation/us/en/software/mist/api/http/api/orgs/integration-skyatp/udpate-org-atp-blocked-list
-
-    PARAMS
-    -----------
-    mistapi.APISession : mist_session
-        mistapi session including authentication and Mist host information
-
-    PATH PARAMS
-    -----------
-    org_id : str
-
-    BODY PARAMS
-    -----------
-    body : dict
-        JSON object to send to Mist Cloud (see API doc above for more details)
-
-    RETURN
-    -----------
-    mistapi.APIResponse
-        response from the API call
-    """
-
-    uri = f"/api/v1/orgs/{org_id}/setting/skyatp/setup/secintel_blocklist"
     resp = mist_session.mist_put(uri=uri, body=body)
     return resp
 

--- a/src/mistapi/api/v1/orgs/wired_clients.py
+++ b/src/mistapi/api/v1/orgs/wired_clients.py
@@ -70,6 +70,7 @@ def searchOrgWiredClients(
     org_id: str,
     auth_state: str | None = None,
     auth_method: str | None = None,
+    source: str | None = None,
     site_id: str | None = None,
     device_mac: str | None = None,
     mac: str | None = None,
@@ -105,6 +106,8 @@ def searchOrgWiredClients(
     ------------
     auth_state : str
     auth_method : str
+    source : str{'lldp', 'mac'}
+      source from where the client was learned (lldp, mac)
     site_id : str
     device_mac : str
     mac : str
@@ -136,6 +139,8 @@ def searchOrgWiredClients(
         query_params["auth_state"] = str(auth_state)
     if auth_method:
         query_params["auth_method"] = str(auth_method)
+    if source:
+        query_params["source"] = str(source)
     if site_id:
         query_params["site_id"] = str(site_id)
     if device_mac:

--- a/src/mistapi/api/v1/sites/devices.py
+++ b/src/mistapi/api/v1/sites/devices.py
@@ -371,6 +371,7 @@ def searchSiteDeviceEvents(
     timestamp: str | None = None,
     type: str | None = None,
     last_by: str | None = None,
+    includes: str | None = None,
     limit: int = 100,
     start: int | None = None,
     end: int | None = None,
@@ -396,6 +397,7 @@ def searchSiteDeviceEvents(
     timestamp : str
     type : str
     last_by : str
+    includes : str
     limit : int, default: 100
     start : int
     end : int
@@ -421,6 +423,8 @@ def searchSiteDeviceEvents(
         query_params["type"] = str(type)
     if last_by:
         query_params["last_by"] = str(last_by)
+    if includes:
+        query_params["includes"] = str(includes)
     if limit:
         query_params["limit"] = str(limit)
     if start:

--- a/src/mistapi/api/v1/sites/nac_clients.py
+++ b/src/mistapi/api/v1/sites/nac_clients.py
@@ -343,6 +343,11 @@ def searchSiteNacClients(
     mxedge_id: str | None = None,
     nacrule_name: str | None = None,
     status: str | None = None,
+    family: str | None = None,
+    model: str | None = None,
+    os: str | None = None,
+    hostname: str | None = None,
+    mfg: str | None = None,
     type: str | None = None,
     mdm_compliance: str | None = None,
     mdm_provider: str | None = None,
@@ -384,6 +389,11 @@ def searchSiteNacClients(
     mxedge_id : str
     nacrule_name : str
     status : str
+    family : str
+    model : str
+    os : str
+    hostname : str
+    mfg : str
     type : str
     mdm_compliance : str
     mdm_provider : str
@@ -435,6 +445,16 @@ def searchSiteNacClients(
         query_params["nacrule_name"] = str(nacrule_name)
     if status:
         query_params["status"] = str(status)
+    if family:
+        query_params["family"] = str(family)
+    if model:
+        query_params["model"] = str(model)
+    if os:
+        query_params["os"] = str(os)
+    if hostname:
+        query_params["hostname"] = str(hostname)
+    if mfg:
+        query_params["mfg"] = str(mfg)
     if type:
         query_params["type"] = str(type)
     if mdm_compliance:

--- a/src/mistapi/api/v1/sites/wired_clients.py
+++ b/src/mistapi/api/v1/sites/wired_clients.py
@@ -88,6 +88,7 @@ def searchSiteWiredClients(
     mac: str | None = None,
     ip: str | None = None,
     port_id: str | None = None,
+    source: str | None = None,
     vlan: str | None = None,
     manufacture: str | None = None,
     text: str | None = None,
@@ -120,6 +121,8 @@ def searchSiteWiredClients(
     mac : str
     ip : str
     port_id : str
+    source : str{'lldp', 'mac'}
+      source from where the client was learned (lldp, mac)
     vlan : str
     manufacture : str
     text : str
@@ -150,6 +153,8 @@ def searchSiteWiredClients(
         query_params["ip"] = str(ip)
     if port_id:
         query_params["port_id"] = str(port_id)
+    if source:
+        query_params["source"] = str(source)
     if vlan:
         query_params["vlan"] = str(vlan)
     if manufacture:


### PR DESCRIPTION
Makefile Updates

Added new targets:

setup-openapi: Initializes and updates the mist_openapi Git submodule.

generate: Now depends on setup-openapi; runs code generation and formats code.

Updated init target: Now depends on setup-openapi to ensure submodule setup during development initialization.

Removed old generate logic: Replaced with cleaner, better-structured logic under the new generate target.

mist_openapi Submodule 

Code changes are triggered from running the generate script.